### PR TITLE
Feat/add superuser envvar

### DIFF
--- a/Pocketspire/Dockerfile
+++ b/Pocketspire/Dockerfile
@@ -22,4 +22,4 @@ RUN chmod +x pb-setup.sh
 
 EXPOSE 8080
 
-CMD ["/bin/sh", "-c", "./pb-setup.sh"]
+ENTRYPOINT ["/bin/sh", "-c", "./pb-setup.sh \"$@\"", "--"]

--- a/Pocketspire/Dockerfile
+++ b/Pocketspire/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM alpine:3 AS base
 
 ARG PB_VERSION=0.24.1
 ARG CPU_ARCH=amd64

--- a/Pocketspire/Dockerfile
+++ b/Pocketspire/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3 AS base
+FROM alpine:3
 
 ARG PB_VERSION=0.24.1
 ARG CPU_ARCH=amd64
@@ -16,7 +16,10 @@ RUN unzip /tmp/pb.zip -d /pb/
 # uncomment to copy the local pb_hooks dir into the image
 # COPY ./pb_hooks /pb/pb_hooks
 
+COPY pb-setup.sh .
+
+RUN chmod +x pb-setup.sh
+
 EXPOSE 8080
 
-# start PocketBase
-CMD ["/pb/pocketbase", "serve", "--http=0.0.0.0:8080"]
+CMD ["/bin/sh", "-c", "./pb-setup.sh"]

--- a/Pocketspire/PocketbaseResourceBuilderExtensions.cs
+++ b/Pocketspire/PocketbaseResourceBuilderExtensions.cs
@@ -21,8 +21,8 @@ public static class PocketbaseResourceBuilderExtensions
     public static IResourceBuilder<ContainerResource> AddPocketbaseContainer(
         this IDistributedApplicationBuilder builder,
         string name,
-        string superUserEmail,
-        string superUserPassword,
+        string? superUserEmail = "",
+        string? superUserPassword = "",
         bool? arm64cpu = false,
         int? exposedPort = null,
         string? pocketbaseVersion = "0.24.1")
@@ -36,8 +36,8 @@ public static class PocketbaseResourceBuilderExtensions
         return builder.AddDockerfile(name: $"pocketbase-{name}", path.Parent.FullName)
             .WithBuildArg("PB_VERSION", pocketbaseVersion ?? throw new ArgumentNullException(nameof(pocketbaseVersion)))
             .WithBuildArg("CPU_ARCH", arm64cpu.HasValue && arm64cpu.Value ? "arm64" : "amd64")
-            .WithEnvironment("PB_SUPERUSER", superUserEmail)
-            .WithEnvironment("PB_SUPERUSER_PW", superUserPassword)
+            .WithEnvironment("PB_SU", superUserEmail)
+            .WithEnvironment("PB_SU_PW", superUserPassword)
             .WithHttpEndpoint(targetPort: 8080, port: exposedPort, name: $"pocketbase-{name}")
             .WithExternalHttpEndpoints();
     }

--- a/Pocketspire/PocketbaseResourceBuilderExtensions.cs
+++ b/Pocketspire/PocketbaseResourceBuilderExtensions.cs
@@ -10,9 +10,11 @@ namespace Pocketspire;
 public static class PocketbaseResourceBuilderExtensions
 {
     /// <summary>
-    /// Adds a Pocketbase container to the Aspire App Host.
+    /// Adds a Pocketbase container to the Aspire App Host. Creation of a superuser is optional for non-production environments. A link is generated at runtime to create a superuser otherwise.
     /// </summary>
     /// <param name="builder">The distributed application builder.</param>
+    /// <param name="superUserEmail">The email of the superuser. Not recommended for production environments.</param>
+    /// <param name="superUserPassword">The password of the superuser. Not recommended for production environments.</param>
     /// <param name="name">The name of the Pocketbase resource.</param>
     /// <param name="exposedPort">The port to expose for the Pocketbase container. Leave blank for a random port.</param>
     /// <param name="pocketbaseVersion">The version of Pocketbase to use. Default is "0.24.1".</param>
@@ -36,8 +38,8 @@ public static class PocketbaseResourceBuilderExtensions
         return builder.AddDockerfile(name: $"pocketbase-{name}", path.Parent.FullName)
             .WithBuildArg("PB_VERSION", pocketbaseVersion ?? throw new ArgumentNullException(nameof(pocketbaseVersion)))
             .WithBuildArg("CPU_ARCH", arm64cpu.HasValue && arm64cpu.Value ? "arm64" : "amd64")
-            .WithEnvironment("PB_SU", superUserEmail)
-            .WithEnvironment("PB_SU_PW", superUserPassword)
+            .WithArgs("PB_SU", superUserEmail!)
+            .WithArgs("PB_SU_PW", superUserPassword!)
             .WithHttpEndpoint(targetPort: 8080, port: exposedPort, name: $"pocketbase-{name}")
             .WithExternalHttpEndpoints();
     }

--- a/Pocketspire/PocketbaseResourceBuilderExtensions.cs
+++ b/Pocketspire/PocketbaseResourceBuilderExtensions.cs
@@ -21,6 +21,8 @@ public static class PocketbaseResourceBuilderExtensions
     public static IResourceBuilder<ContainerResource> AddPocketbaseContainer(
         this IDistributedApplicationBuilder builder,
         string name,
+        string superUserEmail,
+        string superUserPassword,
         bool? arm64cpu = false,
         int? exposedPort = null,
         string? pocketbaseVersion = "0.24.1")
@@ -30,9 +32,12 @@ public static class PocketbaseResourceBuilderExtensions
         if (path.Parent == null)
             throw new Exception("Could not find parent directory");
 
+        // TODO: ./pb/pocketbase superuser create $PB_SUPERUSER $PB_SUPERUSER_PASSWORD needs to run after serve starts
         return builder.AddDockerfile(name: $"pocketbase-{name}", path.Parent.FullName)
             .WithBuildArg("PB_VERSION", pocketbaseVersion ?? throw new ArgumentNullException(nameof(pocketbaseVersion)))
             .WithBuildArg("CPU_ARCH", arm64cpu.HasValue && arm64cpu.Value ? "arm64" : "amd64")
+            .WithEnvironment("PB_SUPERUSER", superUserEmail)
+            .WithEnvironment("PB_SUPERUSER_PW", superUserPassword)
             .WithHttpEndpoint(targetPort: 8080, port: exposedPort, name: $"pocketbase-{name}")
             .WithExternalHttpEndpoints();
     }

--- a/Pocketspire/Pocketspire.csproj
+++ b/Pocketspire/Pocketspire.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 	  <PackageId>Pocketspire</PackageId>
-	  <Version>0.1.1</Version>
+	  <Version>0.2.0</Version>
 	  <Authors>bitobrian</Authors>
 	  <Company></Company>
   </PropertyGroup>
@@ -20,8 +20,17 @@
 			<Pack>true</Pack>
 			<PackagePath>contentFiles\any\any\</PackagePath>
 			<PackageCopyToOutput>true</PackageCopyToOutput>
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</Content>
 	</ItemGroup>
 
+	<ItemGroup>
+		<Content Include="pb-setup.sh">
+			<Pack>true</Pack>
+			<PackagePath>contentFiles\any\any\</PackagePath>
+			<PackageCopyToOutput>true</PackageCopyToOutput>
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</Content>
+	</ItemGroup>
 
 </Project>

--- a/Pocketspire/pb-setup.sh
+++ b/Pocketspire/pb-setup.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Start PocketBase in the background
+./pb/pocketbase serve --http=0.0.0.0:8080 &
+
+# Wait for a moment to ensure PocketBase is up and running
+sleep 5
+
+# Run superuser command only if PB_SU is not empty
+if [ -n "$PB_SU" ]; then
+  ./pb/pocketbase superuser create $PB_SU $PB_SU_PW
+fi
+
+# Keep the container running (wait indefinitely)
+tail -f /dev/null

--- a/Pocketspire/pb-setup.sh
+++ b/Pocketspire/pb-setup.sh
@@ -6,9 +6,13 @@
 # Wait for a moment to ensure PocketBase is up and running
 sleep 5
 
-# Run superuser command only if PB_SU is not empty
-if [ -n "$PB_SU" ]; then
-  ./pb/pocketbase superuser create $PB_SU $PB_SU_PW
+# Assign provided values or use defaults if not provided
+SUPERUSER_NAME=${2:-""}
+SUPERUSER_PASSWORD=${4:-""}
+
+# Check if both SUPERUSER_NAME and SUPERUSER_PASSWORD are non-empty before running the command
+if [ -n "$SUPERUSER_NAME" ] && [ -n "$SUPERUSER_PASSWORD" ]; then
+./pb/pocketbase superuser create "$SUPERUSER_NAME" "$SUPERUSER_PASSWORD"
 fi
 
 # Keep the container running (wait indefinitely)

--- a/Readme.md
+++ b/Readme.md
@@ -27,8 +27,11 @@ var pocketbase = builder.AddPocketbaseContainer("pb");
 ```
 
 ### Parameters
+> Superuser credentials are required for initial setup but a link will also generate in the console for use during first-time setup. See the [pocketbase docs](https://pocketbase.io/docs) for more details.
 
 - **name**: The name of the instance. Appends to the name like: "pocketbase-{name}".
+- **superUserEmail**: The email for the super user.
+- **superUserPassword**: The password for the super user.
 - **arm64cpu** (optional): Use an ARM64 CPU. Default is `false`.
 - **exposedPort** (optional): The port to be exposed. Default is `null`.
 - **pocketbaseVersion** (optional): The version of PocketBase to use. Default is `"0.24.1"`.


### PR DESCRIPTION
Added support for creating super user via build args. This still adds the creds in plain text in the container's run command (in aspire dashboard). Added docs to recommend dev only for this and use the link generation until a better integrated solution.